### PR TITLE
Move forms collection back to Content

### DIFF
--- a/src/components/admin/CustomDashboard.tsx
+++ b/src/components/admin/CustomDashboard.tsx
@@ -1,13 +1,8 @@
 import React from 'react';
+import { CONTENT_COLLECTIONS } from './collectionGroups';
 // Dashboard groups mirror sidebar order
 const GROUPS: Record<string, { slug: string; label: string }[]> = {
-  Content: [
-    { slug: 'posts', label: 'Posts' },
-    { slug: 'pages', label: 'Pages' },
-    { slug: 'wordpress-posts', label: 'Wordpress Posts' },
-    { slug: 'media', label: 'Media' },
-    { slug: 'categories', label: 'Categories' },
-  ],
+  Content: CONTENT_COLLECTIONS,
   Site: [
     { slug: 'navbars', label: 'Navbars' },
     { slug: 'standard-media', label: 'Images and Videos' },

--- a/src/components/admin/collectionGroups.ts
+++ b/src/components/admin/collectionGroups.ts
@@ -1,7 +1,8 @@
 // Centralized config for sidebar and dashboard grouping
 export const CONTENT_COLLECTIONS = [
-  { slug: 'pages', label: 'Pages' },
   { slug: 'posts', label: 'Posts' },
+  { slug: 'pages', label: 'Pages' },
+  { slug: 'wordpress-posts', label: 'Wordpress Posts' },
   { slug: 'media', label: 'Media' },
   { slug: 'categories', label: 'Categories' },
   { slug: 'forms', label: 'Forms' },

--- a/src/lib/plugins.ts
+++ b/src/lib/plugins.ts
@@ -62,6 +62,9 @@ export const plugins: Plugin[] = [
     fields: {
       payment: false,
     },
+    formOverrides: {
+      admin: { group: 'Content' },
+    },
     formSubmissionOverrides: {
       admin: { group: 'Content' },
     },


### PR DESCRIPTION
## Summary
- sync dashboard content section with `collectionGroups`
- include Forms and WordPress posts in Content group
- show Forms in sidebar via formBuilder plugin overrides

## Testing
- `pnpm lint` *(fails: Request was cancelled due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687ea299af28832f8b6fb8b618915f78