### PR TITLE
Fix hero component types

### DIFF
--- a/src/components/heros/high-impact.tsx
+++ b/src/components/heros/high-impact.tsx
@@ -8,7 +8,8 @@ import Link from 'next/link'
 
 import type { Page } from '@/payload-types'
 
-export const HighImpactHero = ({ links, media, richText, callToAction }: Page['hero']) => {
+type HeroProps = NonNullable<Page['hero']>
+export const HighImpactHero = ({ links, media, richText, callToAction }: HeroProps) => {
   return (
     <Section className="bg-accent/30 border-b">
       <Container className="space-y-6 sm:space-y-12 !text-center">

--- a/src/components/heros/low-impact.tsx
+++ b/src/components/heros/low-impact.tsx
@@ -7,7 +7,8 @@ import RichText from '@/components/site/rich-text'
 
 import type { Page } from '@/payload-types'
 
-export const LowImpactHero = ({ richText, links }: Page['hero']) => {
+type HeroProps = NonNullable<Page['hero']>
+export const LowImpactHero = ({ richText, links }: HeroProps) => {
   return (
     <Section className="bg-accent/30 border-b">
       <Container className="space-y-3 sm:space-y-6">

--- a/src/components/heros/medium-impact.tsx
+++ b/src/components/heros/medium-impact.tsx
@@ -8,7 +8,8 @@ import Link from 'next/link'
 
 import type { Page } from '@/payload-types'
 
-export const MediumImpactHero = ({ links, media, richText, callToAction }: Page['hero']) => {
+type HeroProps = NonNullable<Page['hero']>
+export const MediumImpactHero = ({ links, media, richText, callToAction }: HeroProps) => {
   return (
     <Section className="border-b bg-accent/30">
       <Container className="space-y-6 sm:space-y-8">

--- a/src/components/heros/render-hero.tsx
+++ b/src/components/heros/render-hero.tsx
@@ -2,11 +2,13 @@ import React from 'react'
 
 import type { Page } from '@/payload-types'
 
+type HeroProps = NonNullable<Page['hero']>
+
 import { HighImpactHero } from '@/components/heros/high-impact'
 import { LowImpactHero } from '@/components/heros/low-impact'
 import { MediumImpactHero } from '@/components/heros/medium-impact'
 
-const heroes = {
+const heroes: Record<NonNullable<Page['hero']>['type'], React.FC<HeroProps>> = {
   highImpact: HighImpactHero,
   lowImpact: LowImpactHero,
   mediumImpact: MediumImpactHero,
@@ -21,5 +23,5 @@ export const RenderHero: React.FC<Page['hero']> = (props) => {
 
   if (!HeroToRender) return null
 
-  return <HeroToRender {...props} />
+  return <HeroToRender {...(props as HeroProps)} />
 }


### PR DESCRIPTION
## Summary
- specify hero props using `NonNullable<Page['hero']>`
- forward strongly typed props from `render-hero`

## Testing
- `npm run lint` *(fails: cross-env not found)*
- `npm run build` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ecafbe0ac832fa4dcf9774859211d