### PR TITLE
Enable external live preview

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@ PAYLOAD_SECRET=your_secret
 NEXT_PUBLIC_SERVER_URL=http://localhost:3001
 CRON_SECRET=your_cron_secret
 PREVIEW_SECRET=your_preview_secret
+NEXT_PUBLIC_PAYLOAD_URL=http://localhost:3000
 
 # R2 Storage Configuration
 R2_ACCESS_KEY_ID=your_r2_access_key_id

--- a/src/components/site/live-preview-listener.tsx
+++ b/src/components/site/live-preview-listener.tsx
@@ -7,5 +7,6 @@ import React from 'react'
 
 export const LivePreviewListener: React.FC = () => {
   const router = useRouter()
-  return <PayloadLivePreview refresh={router.refresh} serverURL={getClientSideURL()} />
+  const serverURL = process.env.NEXT_PUBLIC_PAYLOAD_URL || getClientSideURL()
+  return <PayloadLivePreview refresh={router.refresh} serverURL={serverURL} />
 }

--- a/src/lib/utilities/generatePreviewPath.ts
+++ b/src/lib/utilities/generatePreviewPath.ts
@@ -1,4 +1,5 @@
 import { PayloadRequest, CollectionSlug } from 'payload'
+import { getServerSideURL } from './getURL'
 
 const collectionPrefixMap: Partial<Record<CollectionSlug, string>> = {
   posts: '/posts',
@@ -19,7 +20,7 @@ export const generatePreviewPath = ({ collection, slug }: Props) => {
     previewSecret: process.env.PREVIEW_SECRET || '',
   })
 
-  const url = `/next/preview?${encodedParams.toString()}`
+  const baseURL = getServerSideURL()
 
-  return url
+  return `${baseURL}/next/preview?${encodedParams.toString()}`
 }


### PR DESCRIPTION
## Summary
- support custom backend URL for live preview
- build full preview URL when generating preview paths
- document NEXT_PUBLIC_PAYLOAD_URL env var

## Testing
- `pnpm --version` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_687faf3fd5b0832fac16a0a9a483cc64