### PR TITLE
Unscope users from multi tenant filter

### DIFF
--- a/src/lib/plugins.ts
+++ b/src/lib/plugins.ts
@@ -86,7 +86,8 @@ export const plugins: Plugin[] = [
     // disable tenant-based access constraints for admins
     useTenantsCollectionAccess: true,
     useTenantsListFilter: true,
-    useUsersTenantFilter: true,
+    // Temporarily disable tenant scoping for users
+    useUsersTenantFilter: false,
     debug: true,
     // allow super users to see all tenants
     userHasAccessToAllTenants: (user) => !!user.roles?.includes('super'),


### PR DESCRIPTION
## Summary
- disable user-based tenant scoping

## Testing
- `pnpm lint` *(fails: unable to download pnpm package)*

------
https://chatgpt.com/codex/tasks/task_e_687fe603f6c4832fb63b1f9d57f31390