### PR TITLE
Fix preview URL generation

### DIFF
--- a/src/lib/utilities/generatePreviewPath.ts
+++ b/src/lib/utilities/generatePreviewPath.ts
@@ -17,10 +17,10 @@ export const generatePreviewPath = ({ collection, slug }: Props) => {
     slug,
     collection,
     path: `${collectionPrefixMap[collection]}/${slug}`,
-    previewSecret: process.env.PREVIEW_SECRET || '',
+    secret: process.env.PREVIEW_SECRET || '',
   })
 
   const baseURL = getServerSideURL()
 
-  return `${baseURL}/next/preview?${encodedParams.toString()}`
+  return `${baseURL}/api/preview?${encodedParams.toString()}`
 }


### PR DESCRIPTION
## Summary
- point preview URLs at `/api/preview`

## Testing
- `pnpm lint` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688144f3b4f4832f8210f660a875e80d