### PR TITLE
Fix preview URL handling

### DIFF
--- a/src/app/api/preview/route.ts
+++ b/src/app/api/preview/route.ts
@@ -1,7 +1,12 @@
 import { draftMode } from 'next/headers'
 import { NextRequest, NextResponse } from 'next/server'
 
-// GET /api/preview?secret=...&path=/slug
+const collectionPrefixMap = {
+  posts: '/posts',
+  pages: '',
+}
+
+// GET /api/preview?secret=...&slug=...&collection=pages
 export async function GET(req: NextRequest) {
   const secret = req.nextUrl.searchParams.get('secret') || ''
   const expected = process.env.PREVIEW_SECRET || ''
@@ -15,7 +20,14 @@ export async function GET(req: NextRequest) {
   enable()
 
   // Redirect to the provided path (default to /)
-  const path = req.nextUrl.searchParams.get('path') || '/'
+  const slug = req.nextUrl.searchParams.get('slug') || ''
+  const collection = req.nextUrl.searchParams.get('collection') || ''
+  let path = req.nextUrl.searchParams.get('path') || '/'
+
+  if (slug && collection && collection in collectionPrefixMap) {
+    path = `${collectionPrefixMap[collection as keyof typeof collectionPrefixMap]}/${slug}`
+  }
+
   const redirectURL = new URL(path, req.nextUrl.origin)
 
   // Attach Payload preview JWT so the front-end can fetch drafts from the API

--- a/src/collections/Pages/index.ts
+++ b/src/collections/Pages/index.ts
@@ -14,6 +14,7 @@ import { HeroConfig } from '@/components/heros/config'
 import { slugField } from '@/collections/fields/slug'
 import { populatePublishedAt } from '@/lib/hooks/populatePublishedAt'
 import { generatePreviewPath } from '@/lib/utilities/generatePreviewPath'
+import { generatePreviewAPIUrl } from '@/lib/utilities/generatePreviewAPIUrl'
 import { revalidateDelete, revalidatePage } from './hooks/revalidatePage'
 
 import {
@@ -40,11 +41,10 @@ export const Pages: CollectionConfig<'pages'> = {
     group: 'Content',
     defaultColumns: ['title', 'slug', 'updatedAt'],
     livePreview: {
-      url: ({ data, req }) => {
-        const path = generatePreviewPath({
+      url: ({ data }) => {
+        const path = generatePreviewAPIUrl({
           slug: typeof data?.slug === 'string' ? data.slug : '',
           collection: 'pages',
-          req,
         })
 
         return path

--- a/src/lib/utilities/generatePreviewAPIUrl.ts
+++ b/src/lib/utilities/generatePreviewAPIUrl.ts
@@ -1,0 +1,24 @@
+import { CollectionSlug } from 'payload'
+import { getServerSideURL } from './getURL'
+
+const collectionPrefixMap: Partial<Record<CollectionSlug, string>> = {
+  posts: '/posts',
+  pages: '',
+}
+
+type Props = {
+  collection: keyof typeof collectionPrefixMap
+  slug: string
+}
+
+export const generatePreviewAPIUrl = ({ collection, slug }: Props) => {
+  const encodedParams = new URLSearchParams({
+    slug,
+    collection,
+    secret: process.env.PREVIEW_SECRET || '',
+  })
+
+  const baseURL = getServerSideURL()
+
+  return `${baseURL}/api/preview?${encodedParams.toString()}`
+}


### PR DESCRIPTION
## Summary
- support slug and collection parameters in `/api/preview`
- simplify preview URL helper
- update Pages live preview URL

## Testing
- `pnpm lint` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688144f3b4f4832f8210f660a875e80d