### PR TITLE
Enable tenant dropdown for normal users

### DIFF
--- a/src/lib/plugins.ts
+++ b/src/lib/plugins.ts
@@ -86,8 +86,8 @@ export const plugins: Plugin[] = [
     // disable tenant-based access constraints for admins
     useTenantsCollectionAccess: true,
     useTenantsListFilter: true,
-    // Temporarily disable tenant scoping for users
-    useUsersTenantFilter: false,
+    // enable tenant scoping for users so normal users can switch tenants
+    useUsersTenantFilter: true,
     debug: true,
     // allow super users to see all tenants
     userHasAccessToAllTenants: (user) => !!user.roles?.includes('super'),


### PR DESCRIPTION
## Summary
- allow tenant scoping for users so normal users get the tenant dropdown

## Testing
- `pnpm lint`
- `pnpm build` *(fails: cannot connect to MongoDB)*

------
https://chatgpt.com/codex/tasks/task_e_688277165198832fb7437555bd24e654