### PR TITLE
Enable tenant dropdown for normal users

### DIFF
--- a/src/collections/Tenants.ts
+++ b/src/collections/Tenants.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig } from 'payload'
+import { getTenantAccess } from '@payloadcms/plugin-multi-tenant/utilities'
 
 export const Tenants: CollectionConfig = {
   slug: 'tenants',
@@ -11,7 +12,23 @@ export const Tenants: CollectionConfig = {
     group: 'Admin',
   },
   access: {
-    read: () => true,
+    read: ({ req }) => {
+      if (req.user?.roles?.includes('super')) {
+        return true
+      }
+
+      const referer = (req.headers as Record<string, string> | undefined)?.referer || ''
+      if (referer.includes('/admin/collections/users')) {
+        // allow users to see all tenants when editing a user profile
+        return true
+      }
+
+      if (req.user) {
+        return getTenantAccess({ fieldName: 'id', user: req.user })
+      }
+
+      return false
+    },
     create: ({ req }) => !!req.user?.roles?.includes('super'),
     update: ({ req }) => !!req.user?.roles?.includes('super'),
     delete: ({ req }) => !!req.user?.roles?.includes('super'), // only super admins can delete

--- a/src/lib/plugins.ts
+++ b/src/lib/plugins.ts
@@ -83,11 +83,11 @@ export const plugins: Plugin[] = [
   // Multi-tenant must run first so other plugins respect tenant scoping
   multiTenantPlugin({
     tenantsSlug: 'tenants',     // identify the Tenants collection
-    // disable tenant-based access constraints for admins
-    useTenantsCollectionAccess: true,
+    // we will handle tenant collection access manually
+    useTenantsCollectionAccess: false,
     useTenantsListFilter: true,
-    // Temporarily disable tenant scoping for users
-    useUsersTenantFilter: false,
+    // enable tenant scoping for users so normal users can switch tenants
+    useUsersTenantFilter: true,
     debug: true,
     // allow super users to see all tenants
     userHasAccessToAllTenants: (user) => !!user.roles?.includes('super'),


### PR DESCRIPTION
## Summary
- handle tenant access manually and let regular users see all tenants on their profile
- return all tenants when editing own user but otherwise scope by user's tenants

## Testing
- `pnpm lint`
- `pnpm build` *(fails: unable to find build-manifest)*


------
https://chatgpt.com/codex/tasks/task_e_688277165198832fb7437555bd24e654