### PR TITLE
Enable tenant dropdown for normal users

### DIFF
--- a/src/lib/plugins.ts
+++ b/src/lib/plugins.ts
@@ -83,11 +83,11 @@ export const plugins: Plugin[] = [
   // Multi-tenant must run first so other plugins respect tenant scoping
   multiTenantPlugin({
     tenantsSlug: 'tenants',     // identify the Tenants collection
-    // disable tenant-based access constraints for admins
-    useTenantsCollectionAccess: true,
+    // we will handle tenant collection access manually
+    useTenantsCollectionAccess: false,
     useTenantsListFilter: true,
-    // Temporarily disable tenant scoping for users
-    useUsersTenantFilter: false,
+    // enable tenant scoping for users so normal users can switch tenants
+    useUsersTenantFilter: true,
     debug: true,
     // allow super users to see all tenants
     userHasAccessToAllTenants: (user) => !!user.roles?.includes('super'),


### PR DESCRIPTION
## Summary
- handle tenant access manually and let regular users see all tenants on their profile
- return all tenants when editing own user but otherwise scope by user's tenants
- fix `req.headers` typing when reading the referer

## Testing
- `pnpm lint`
- `pnpm build` *(fails: cannot connect to MongoDB)*

------
https://chatgpt.com/codex/tasks/task_e_688277165198832fb7437555bd24e654