### PR TITLE
Add social link fields to RepInfo collection

### DIFF
--- a/src/collections/RepInfo/index.ts
+++ b/src/collections/RepInfo/index.ts
@@ -53,5 +53,29 @@ export const RepInfo: CollectionConfig = {
       relationTo: 'forms',
       required: false,
     },
+    {
+      name: 'facebook',
+      label: 'Facebook',
+      type: 'text',
+      required: false,
+    },
+    {
+      name: 'youtube',
+      label: 'YouTube',
+      type: 'text',
+      required: false,
+    },
+    {
+      name: 'instagram',
+      label: 'Instagram',
+      type: 'text',
+      required: false,
+    },
+    {
+      name: 'x',
+      label: 'X',
+      type: 'text',
+      required: false,
+    },
   ],
 }

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -224,6 +224,7 @@ export interface Tenant {
  */
 export interface Media {
   id: string;
+  tenant?: (string | null) | Tenant;
   alt?: string | null;
   caption?: {
     root: {
@@ -347,6 +348,9 @@ export interface User {
     | null;
   updatedAt: string;
   createdAt: string;
+  enableAPIKey?: boolean | null;
+  apiKey?: string | null;
+  apiKeyIndex?: string | null;
   email: string;
   resetPasswordToken?: string | null;
   resetPasswordExpiration?: string | null;
@@ -1019,6 +1023,10 @@ export interface RepInfo {
       }[]
     | null;
   form?: (string | null) | Form;
+  facebook?: string | null;
+  youtube?: string | null;
+  instagram?: string | null;
+  x?: string | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -1579,6 +1587,7 @@ export interface WordpressPostsSelect<T extends boolean = true> {
  * via the `definition` "media_select".
  */
 export interface MediaSelect<T extends boolean = true> {
+  tenant?: T;
   alt?: T;
   caption?: T;
   updatedAt?: T;
@@ -1774,6 +1783,10 @@ export interface RepInfoSelect<T extends boolean = true> {
         id?: T;
       };
   form?: T;
+  facebook?: T;
+  youtube?: T;
+  instagram?: T;
+  x?: T;
   updatedAt?: T;
   createdAt?: T;
 }
@@ -1810,6 +1823,9 @@ export interface UsersSelect<T extends boolean = true> {
       };
   updatedAt?: T;
   createdAt?: T;
+  enableAPIKey?: T;
+  apiKey?: T;
+  apiKeyIndex?: T;
   email?: T;
   resetPasswordToken?: T;
   resetPasswordExpiration?: T;


### PR DESCRIPTION
## Summary
- expand RepInfo collection fields with Facebook, YouTube, Instagram and X links
- regenerate Payload types

## Testing
- `pnpm lint`
- `pnpm build` *(fails: cannot connect to MongoDB)*

------
https://chatgpt.com/codex/tasks/task_e_688361abd1d0832f85b2f1fd97790f3e