### PR TITLE
Add tenant SEO data to homepage

### DIFF
--- a/src/components/site/site-seo-info.tsx
+++ b/src/components/site/site-seo-info.tsx
@@ -1,0 +1,25 @@
+import { Section, Container } from '@/components/layout'
+import type { SiteSeo } from '@/payload-types'
+
+export function SiteSEOInfo({ seo }: { seo: SiteSeo }) {
+  if (!seo) return null
+
+  return (
+    <Section>
+      <Container>
+        <div className="prose dark:prose-invert">
+          <h2>{seo.title}</h2>
+          <p>{seo.description}</p>
+          {seo.tags && seo.tags.length > 0 && (
+            <p>
+              <strong>Tags:</strong> {seo.tags.map((t) => t.tag).join(', ')}
+            </p>
+          )}
+          {typeof seo.metaImage === 'object' && seo.metaImage?.url && (
+            <img src={seo.metaImage.url} alt={seo.title} />
+          )}
+        </div>
+      </Container>
+    </Section>
+  )
+}

--- a/src/lib/utilities/getSiteSEO.ts
+++ b/src/lib/utilities/getSiteSEO.ts
@@ -1,0 +1,20 @@
+import configPromise from '@payload-config'
+import { getPayload } from 'payload'
+
+export async function getSiteSEO(tenantSlug: string) {
+  const payload = await getPayload({ config: configPromise })
+
+  const result = await payload.find({
+    collection: 'site-seo',
+    depth: 2,
+    limit: 1,
+    pagination: false,
+    where: {
+      'tenant.slug': {
+        equals: tenantSlug,
+      },
+    },
+  })
+
+  return result.docs?.[0] || null
+}


### PR DESCRIPTION
## Summary
- fetch default SEO info from the `site-seo` collection
- expose a utility `getSiteSEO`
- show SEO details on the home page
- use fetched SEO data for base metadata

## Testing
- `pnpm lint`
- `pnpm build` *(fails: cannot connect to MongoDB)*

------
https://chatgpt.com/codex/tasks/task_e_6883e430cbd0832faa817f5936191d6b