### PR TITLE
Reorder Site Settings collections

### DIFF
--- a/src/collections/Categories.ts
+++ b/src/collections/Categories.ts
@@ -13,7 +13,7 @@ export const Categories: CollectionConfig = {
     update: authenticated,
   },
   admin: {
-    group: 'Content',
+    group: 'Admin',
     useAsTitle: 'title',
   },
   fields: [

--- a/src/collections/RepInfo/index.ts
+++ b/src/collections/RepInfo/index.ts
@@ -7,7 +7,7 @@ export const RepInfo: CollectionConfig = {
   },
   slug: 'rep-info',
   admin: {
-    group: 'Site',
+    group: 'Site Settings',
     useAsTitle: 'name',
     defaultColumns: ['name', 'districtNumber', 'updatedAt'],
   },

--- a/src/collections/SiteSEO/index.ts
+++ b/src/collections/SiteSEO/index.ts
@@ -7,7 +7,7 @@ export const SiteSEO: CollectionConfig = {
   },
   slug: 'site-seo',
   admin: {
-    group: 'Site',
+    group: 'Site Settings',
     useAsTitle: 'title',
     defaultColumns: ['title', 'updatedAt'],
     description: 'SEO metadata for the tenant home page',

--- a/src/collections/StandardMedia/index.ts
+++ b/src/collections/StandardMedia/index.ts
@@ -2,12 +2,12 @@ import type { CollectionConfig } from 'payload'
 
 export const StandardMedia: CollectionConfig = {
   labels: {
-    singular: 'Images and Videos',
-    plural: 'Images and Videos',
+    singular: 'Standard Photos',
+    plural: 'Standard Photos',
   },
   slug: 'standard-media',
   admin: {
-    group: 'Site',
+    group: 'Site Settings',
     useAsTitle: 'title',
     defaultColumns: ['title', 'updatedAt'],
   },

--- a/src/collections/WordpressPosts/index.ts
+++ b/src/collections/WordpressPosts/index.ts
@@ -5,6 +5,10 @@ import { generatePreviewPath } from '@/lib/utilities/generatePreviewPath'
 // multi-tenant plugin, so a hidden `tenant` field will be injected automatically.
 // All imported posts will initially belong to the Candelora tenant via the import script.
 export const WordpressPosts: CollectionConfig<'wordpress-posts'> = {
+  labels: {
+    singular: 'Wordpress Archive',
+    plural: 'Wordpress Archive',
+  },
   slug: 'wordpress-posts',
   admin: {
     group: 'Content',

--- a/src/components/admin/CustomDashboard.tsx
+++ b/src/components/admin/CustomDashboard.tsx
@@ -3,13 +3,18 @@ import { CONTENT_COLLECTIONS } from './collectionGroups';
 // Dashboard groups mirror sidebar order
 const GROUPS: Record<string, { slug: string; label: string }[]> = {
   Content: CONTENT_COLLECTIONS,
-  Site: [
-    { slug: 'navbars', label: 'Navbars' },
-    { slug: 'standard-media', label: 'Images and Videos' },
+  'Site Settings': [
     { slug: 'rep-info', label: 'Rep Info' },
+    { slug: 'navbars', label: 'Navbars' },
+    { slug: 'standard-media', label: 'Standard Photos' },
     { slug: 'site-seo', label: 'Site SEO' },
   ],
+  'Forms and Surveys': [
+    { slug: 'forms', label: 'Forms' },
+    { slug: 'form-submissions', label: 'Form Submissions' },
+  ],
   Admin: [
+    { slug: 'categories', label: 'Categories' },
     { slug: 'users', label: 'Users' },
     { slug: 'tenants', label: 'Tenants' },
   ],

--- a/src/components/admin/collectionGroups.ts
+++ b/src/components/admin/collectionGroups.ts
@@ -2,9 +2,6 @@
 export const CONTENT_COLLECTIONS = [
   { slug: 'posts', label: 'Posts' },
   { slug: 'pages', label: 'Pages' },
-  { slug: 'wordpress-posts', label: 'Wordpress Posts' },
+  { slug: 'wordpress-posts', label: 'Wordpress Archive' },
   { slug: 'media', label: 'Media' },
-  { slug: 'categories', label: 'Categories' },
-  { slug: 'forms', label: 'Forms' },
-  { slug: 'form-submissions', label: 'Form Submissions' },
 ];

--- a/src/components/site/footer/config.ts
+++ b/src/components/site/footer/config.ts
@@ -4,7 +4,7 @@ import { link } from '@/collections/fields/link'
 import { revalidateFooter } from './hooks/revalidateFooter'
 
 export const Footer: GlobalConfig = {
-  admin: { group: 'Site', hidden: true },
+  admin: { group: 'Site Settings', hidden: true },
   slug: 'footer',
   access: {
     read: () => true,

--- a/src/components/site/header/config.ts
+++ b/src/components/site/header/config.ts
@@ -4,7 +4,7 @@ import { link } from '@/collections/fields/link'
 import { revalidateHeader } from './hooks/revalidateHeader'
 
 export const Header: GlobalConfig = {
-  admin: { group: 'Site', hidden: true },
+  admin: { group: 'Site Settings', hidden: true },
   slug: 'header',
   access: {
     read: () => true,

--- a/src/components/site/navbar/config.ts
+++ b/src/components/site/navbar/config.ts
@@ -8,7 +8,7 @@ export const Navbar: CollectionConfig = {
   admin: {
     useAsTitle: 'name',
     defaultColumns: ['name', 'updatedAt'],
-    group: 'Site',
+    group: 'Site Settings',
   },
   access: {
     read: () => true,

--- a/src/lib/plugins.ts
+++ b/src/lib/plugins.ts
@@ -63,10 +63,10 @@ export const plugins: Plugin[] = [
       payment: false,
     },
     formOverrides: {
-      admin: { group: 'Content' },
+      admin: { group: 'Forms and Surveys' },
     },
     formSubmissionOverrides: {
-      admin: { group: 'Content' },
+      admin: { group: 'Forms and Surveys' },
     },
   }),
   searchPlugin({

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -77,7 +77,7 @@ export default buildConfig({
   db: mongooseAdapter({
     url: process.env.MONGODB_URI || '',
   }),
-  // Reordered to control sidebar group order (Content, Site, Admin, Misc)
+  // Reordered to control sidebar group order (Content, Site Settings, Forms and Surveys, Admin, Misc)
   collections: [
     // Content
     Posts,
@@ -86,9 +86,9 @@ export default buildConfig({
     Media,
     Categories,
     // Site
+    RepInfo,
     Navbar,
     StandardMedia,
-    RepInfo,
     SiteSEO,
     // Admin
     Users,


### PR DESCRIPTION
## Summary
- move Rep Info above Navbars in Site Settings group for the sidebar

## Testing
- `pnpm lint`
- `pnpm build` *(fails: missing secret key)*

------
https://chatgpt.com/codex/tasks/task_e_6888feadfcb8832fbe8a1c7d9ec3a1f4