### PR TITLE
Fix forms group naming

### DIFF
--- a/src/components/admin/CustomDashboard.tsx
+++ b/src/components/admin/CustomDashboard.tsx
@@ -9,7 +9,7 @@ const GROUPS: Record<string, { slug: string; label: string }[]> = {
     { slug: 'standard-media', label: 'Standard Photos' },
     { slug: 'site-seo', label: 'Site SEO' },
   ],
-  'Forms and Surveys': [
+  'Forms & Submissions': [
     { slug: 'forms', label: 'Forms' },
     { slug: 'form-submissions', label: 'Form Submissions' },
   ],
@@ -17,10 +17,6 @@ const GROUPS: Record<string, { slug: string; label: string }[]> = {
     { slug: 'categories', label: 'Categories' },
     { slug: 'users', label: 'Users' },
     { slug: 'tenants', label: 'Tenants' },
-  ],
-  'Forms and Surveys': [
-    { slug: 'forms', label: 'Forms' },
-    { slug: 'form-submissions', label: 'Form Submissions' },
   ],
   Misc: [
     { slug: 'authors', label: 'Authors' },

--- a/src/lib/plugins.ts
+++ b/src/lib/plugins.ts
@@ -63,10 +63,10 @@ export const plugins: Plugin[] = [
       payment: false,
     },
     formOverrides: {
-      admin: { group: 'Forms and Surveys' },
+      admin: { group: 'Forms & Submissions' },
     },
     formSubmissionOverrides: {
-      admin: { group: 'Forms and Surveys' },
+      admin: { group: 'Forms & Submissions' },
     },
   }),
   searchPlugin({

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -77,7 +77,7 @@ export default buildConfig({
   db: mongooseAdapter({
     url: process.env.MONGODB_URI || '',
   }),
-  // Reordered to control sidebar group order (Content, Site Settings, Forms and Surveys, Admin, Misc)
+  // Reordered to control sidebar group order (Content, Site Settings, Forms & Submissions, Admin, Misc)
   collections: [
     // Content
     Posts,


### PR DESCRIPTION
## Summary
- rename 'Forms and Surveys' group to 'Forms & Submissions'
- remove duplicate group declaration
- update form builder plugin group label
- update comment in payload config

## Testing
- `pnpm lint`
- `pnpm build` *(fails: cannot connect to MongoDB)*

------
https://chatgpt.com/codex/tasks/task_e_68891c1ec6c0832f8a2d073c3afc5bf6