### PR TITLE
Customize Payload admin branding

### DIFF
--- a/src/components/payload/Icon.tsx
+++ b/src/components/payload/Icon.tsx
@@ -1,0 +1,12 @@
+'use client'
+import React from 'react'
+
+const Icon: React.FC = () => {
+  const theme = typeof window !== 'undefined'
+    ? document.documentElement.getAttribute('data-theme')
+    : 'light'
+  const src = theme === 'dark' ? '/brand/icon-dark.svg' : '/brand/icon-light.svg'
+  return <img src={src} alt="Breadcrumb Icon" style={{ height: '16px' }} />
+}
+
+export default Icon

--- a/src/components/payload/Logo.tsx
+++ b/src/components/payload/Logo.tsx
@@ -1,0 +1,12 @@
+'use client'
+import React from 'react'
+
+const Logo: React.FC = () => {
+  const theme = typeof window !== 'undefined'
+    ? document.documentElement.getAttribute('data-theme')
+    : 'light'
+  const src = theme === 'dark' ? '/brand/logo-dark.svg' : '/brand/logo-light.svg'
+  return <img src={src} alt="Admin Logo" style={{ height: '32px' }} />
+}
+
+export default Logo

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -44,6 +44,10 @@ export default buildConfig({
           path: '/',
         } as any,
       },
+      graphics: {
+        Logo: './components/payload/Logo#default',
+        Icon: './components/payload/Icon#default',
+      },
     },
     importMap: {
       baseDir: path.resolve(dirname),


### PR DESCRIPTION
## Summary
- add logo and icon components for Payload admin
- reference the custom branding components in `payload.config.ts`

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68893f817bac832f9c3a50a0ca63c12a