### PR TITLE
Add unified feed API endpoint

### DIFF
--- a/src/lib/unifiedFeed.js
+++ b/src/lib/unifiedFeed.js
@@ -1,0 +1,15 @@
+export function mergeAndSort(posts = [], wpPosts = []) {
+  const normalize = (doc, collection) => ({
+    collection,
+    id: doc.id,
+    title: doc.title,
+    slug: doc.slug,
+    publishedDate: doc.publishedAt || doc.publishedDate || doc.createdAt,
+    excerpt: doc.excerpt ?? doc.summary ?? '',
+  })
+
+  return [
+    ...posts.map((d) => normalize(d, 'posts')),
+    ...wpPosts.map((d) => normalize(d, 'wordpressposts')),
+  ].sort((a, b) => new Date(b.publishedDate).getTime() - new Date(a.publishedDate).getTime())
+}

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -16,6 +16,7 @@ import { Users } from './collections/Users';
 import { Authors } from './collections/Authors';
 import { Tags } from './collections/Tags';
 import { WordpressPosts } from './collections/WordpressPosts';
+import { mergeAndSort } from './lib/unifiedFeed.js';
 
 // Site settings and other component imports
 import { Navbar } from './components/site/navbar/config';
@@ -168,5 +169,43 @@ export default buildConfig({
     },
     tasks: [],
   },
+  endpoints: [
+    {
+      path: '/api/unified-feed',
+      method: 'get',
+      handler: async (req) => {
+        const limit = Number((req.query?.limit as string) || 10)
+        const page = Number((req.query?.page as string) || 1)
+        const tenant = req.query?.tenant as string
+
+        if (!tenant) {
+          return Response.json({ error: 'tenant query param is required' }, { status: 400 })
+        }
+
+        const options: any = {
+          depth: req.query.depth,
+          select: req.query.select,
+          where: req.query.where ? JSON.parse(req.query.where as string) : undefined,
+          sort: req.query.sort,
+          tenant,
+          limit: 0,
+        }
+
+        const [posts, wpPosts] = await Promise.all([
+          req.payload.find({ collection: 'posts', ...options }),
+          req.payload.find({ collection: 'wordpress-posts', ...options }),
+        ])
+
+        const merged = mergeAndSort(posts.docs, wpPosts.docs)
+
+        const total = merged.length
+        const totalPages = Math.ceil(total / limit)
+        const start = (page - 1) * limit
+        const paginated = merged.slice(start, start + limit)
+
+        return Response.json({ data: paginated, total, page, totalPages })
+      },
+    },
+  ],
 });
 

--- a/tests/unifiedFeed.test.js
+++ b/tests/unifiedFeed.test.js
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import { mergeAndSort } from '../src/lib/unifiedFeed.js'
+
+test('merges and sorts by published date desc', () => {
+  const posts = [
+    { id: '1', title: 'Post', slug: 'p1', publishedAt: '2024-01-01' },
+  ]
+  const wp = [
+    { id: '2', title: 'WP', slug: 'w1', publishedAt: '2024-01-02' },
+  ]
+  const result = mergeAndSort(posts, wp)
+  assert.equal(result.length, 2)
+  assert.equal(result[0].id, '2')
+  assert.equal(result[0].collection, 'wordpressposts')
+})
+
+test('normalizes fields', () => {
+  const posts = [
+    { id: '1', title: 'Post', slug: 'p1', publishedAt: '2024-01-03', excerpt: 'ex' },
+  ]
+  const wp = []
+  const [doc] = mergeAndSort(posts, wp)
+  assert.deepEqual(doc, {
+    collection: 'posts',
+    id: '1',
+    title: 'Post',
+    slug: 'p1',
+    publishedDate: '2024-01-03',
+    excerpt: 'ex',
+  })
+})


### PR DESCRIPTION
## Summary
- implement `/api/unified-feed` endpoint to combine Posts and WordpressPosts
- add merging helper
- test merge sorting logic

## Testing
- `node --test tests/unifiedFeed.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688b96442908832fa428433ee92fab83