### PR TITLE
Add radio field block

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-label": "^2.1.7",
+    "@radix-ui/react-radio-group": "^1.3.7",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-slot": "^1.2.3",
     "@vercel/analytics": "^1.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@radix-ui/react-label':
         specifier: ^2.1.7
         version: 2.1.7(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-radio-group':
+        specifier: ^1.3.7
+        version: 1.3.7(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-select':
         specifier: ^2.2.5
         version: 2.2.5(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -1800,6 +1803,19 @@ packages:
 
   '@radix-ui/react-primitive@2.1.3':
     resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-radio-group@1.3.7':
+    resolution: {integrity: sha512-9w5XhD0KPOrm92OTTE0SysH3sYzHsSTHNvZgUBo/VZ80VdYyB5RneDbc0dKpURS24IxkoFRu/hI0i4XyfFwY6g==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -7668,6 +7684,24 @@ snapshots:
   '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@radix-ui/react-slot': 1.2.3(@types/react@19.0.10)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.10
+      '@types/react-dom': 19.0.4(@types/react@19.0.10)
+
+  '@radix-ui/react-radio-group@1.3.7(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-presence': 1.1.4(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-roving-focus': 1.1.10(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.0.10)(react@19.0.0)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.0.10)(react@19.0.0)
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:

--- a/src/components/blocks/form-block/fields.tsx
+++ b/src/components/blocks/form-block/fields.tsx
@@ -3,6 +3,7 @@ import { Country } from './country'
 import { Email } from './email'
 import { Message } from './message'
 import { Number } from './number'
+import { Radio } from './radio'
 import { Select } from './select'
 import { State } from './state'
 import { Text } from './text'
@@ -14,6 +15,7 @@ export const fields = {
   email: Email,
   message: Message,
   number: Number,
+  radio: Radio,
   select: Select,
   state: State,
   text: Text,

--- a/src/components/blocks/form-block/radio/index.tsx
+++ b/src/components/blocks/form-block/radio/index.tsx
@@ -1,0 +1,59 @@
+import type { SelectFieldOption } from '@payloadcms/plugin-form-builder/types'
+import type { Control, FieldErrorsImpl } from 'react-hook-form'
+
+import { Label } from '@/components/ui/label'
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
+import React from 'react'
+import { Controller } from 'react-hook-form'
+
+import { Error } from '../error'
+import { Width } from '../width'
+
+interface RadioField {
+  blockName?: string
+  blockType: 'radio'
+  defaultValue?: string
+  label?: string
+  name: string
+  options: SelectFieldOption[]
+  placeholder?: string
+  required?: boolean
+  width?: number
+}
+
+export const Radio: React.FC<
+  RadioField & {
+    control: Control
+    errors: Partial<FieldErrorsImpl>
+  }
+> = ({ name, control, errors, label, options, required, width }) => {
+  return (
+    <Width width={width}>
+      <Label className="mb-2" htmlFor={name}>
+        {label}
+        {required && (
+          <span className="required">
+            * <span className="sr-only">(required)</span>
+          </span>
+        )}
+      </Label>
+      <Controller
+        control={control}
+        defaultValue=""
+        name={name}
+        render={({ field: { onChange, value } }) => (
+          <RadioGroup onValueChange={onChange} value={value} id={name} className="flex flex-col space-y-2">
+            {options.map(({ label, value }) => (
+              <label key={value} className="flex items-center space-x-2">
+                <RadioGroupItem value={value} />
+                <span>{label}</span>
+              </label>
+            ))}
+          </RadioGroup>
+        )}
+        rules={{ required }}
+      />
+      {errors[name] && <Error />}
+    </Width>
+  )
+}

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import * as RadioGroupPrimitive from '@radix-ui/react-radio-group'
+import { Circle } from 'lucide-react'
+import React from 'react'
+import { cn } from '@/lib/utils'
+
+const RadioGroup = RadioGroupPrimitive.Root
+
+const RadioGroupItem: React.FC<
+  { ref?: React.Ref<HTMLButtonElement> } & React.ComponentProps<typeof RadioGroupPrimitive.Item>
+> = ({ className, ref, children, ...props }) => (
+  <RadioGroupPrimitive.Item
+    ref={ref}
+    className={cn(
+      'aspect-square h-4 w-4 rounded-full border border-primary text-primary-foreground shadow focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary',
+      className,
+    )}
+    {...props}
+  >
+    <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
+      {children || <Circle className="h-2.5 w-2.5 fill-current" />}
+    </RadioGroupPrimitive.Indicator>
+  </RadioGroupPrimitive.Item>
+)
+
+export { RadioGroup, RadioGroupItem }


### PR DESCRIPTION
## Summary
- introduce RadioGroup UI component
- implement radio field block
- include new block in form field mapping
- install `@radix-ui/react-radio-group` dependency

## Testing
- `pnpm lint`
- `pnpm build` *(fails: cannot connect to MongoDB)*

------
https://chatgpt.com/codex/tasks/task_e_688c322d395c832f9cd419948ba48241