### PR TITLE
Configure Resend email adapter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,8 @@ R2_ACCESS_KEY_ID=your_r2_access_key_id
 R2_SECRET_ACCESS_KEY=your_r2_secret_access_key
 R2_BUCKET=your_bucket_name
 R2_ENDPOINT=your_r2_endpoint
+
+# Resend Email Configuration
+RESEND_API_KEY=pk_your_resend_key
+RESEND_FROM_EMAIL=info@yourdomain.com
+RESEND_FROM_NAME=Your Site Name

--- a/src/lib/plugins.ts
+++ b/src/lib/plugins.ts
@@ -104,6 +104,7 @@ export const plugins: Plugin[] = [
     formSubmissionOverrides: {
       admin: { group: 'Forms & Submissions' },
     },
+    defaultToEmail: process.env.RESEND_FROM_EMAIL || '',
   }),
   searchPlugin({
     collections: ['posts'],

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -1,5 +1,6 @@
 import { mongooseAdapter } from '@payloadcms/db-mongodb';
 import { formBuilderPlugin } from '@payloadcms/plugin-form-builder';
+import { resendAdapter } from '@payloadcms/email-resend';
 import sharp from 'sharp';
 import path from 'path';
 import { buildConfig, PayloadRequest } from 'payload';
@@ -64,6 +65,12 @@ export default buildConfig({
   // Database configuration
   db: mongooseAdapter({
     url: process.env.MONGODB_URI || '',
+  }),
+
+  email: resendAdapter({
+    defaultFromAddress: process.env.RESEND_FROM_EMAIL || '',
+    defaultFromName: process.env.RESEND_FROM_NAME || '',
+    apiKey: process.env.RESEND_API_KEY || '',
   }),
 
   // Define collections in the desired order; forms will be inserted later.
@@ -141,6 +148,7 @@ export default buildConfig({
       formSubmissionOverrides: {
         admin: { group: 'Forms & Submissions' },
       },
+      defaultToEmail: process.env.RESEND_FROM_EMAIL,
     }),
 
     // Inline plugin to reposition the form collections right after the last Site Settings collection.


### PR DESCRIPTION
## Summary
- add Resend email env variables
- configure Payload to use the Resend adapter
- set defaultToEmail for the form builder plugin

## Testing
- `pnpm lint`
- `pnpm build` *(fails: cannot connect to MongoDB)*

------
https://chatgpt.com/codex/tasks/task_e_688c8706814c832fa409123568786eaf