### PR TITLE
feat: add image select form field

### DIFF
--- a/src/components/blocks/form-block/fields.tsx
+++ b/src/components/blocks/form-block/fields.tsx
@@ -9,6 +9,7 @@ import { Select } from './select'
 import { State } from './state'
 import { Text } from './text'
 import { Textarea } from './textarea'
+import { ImageSelect } from './image-select'
 
 export const fields = {
   checkbox: Checkbox,
@@ -18,6 +19,7 @@ export const fields = {
   number: Number,
   radio: Radio,
   'checkbox-group': CheckboxGroup,
+  'image-select': ImageSelect,
   select: Select,
   state: State,
   text: Text,

--- a/src/components/blocks/form-block/image-select/index.tsx
+++ b/src/components/blocks/form-block/image-select/index.tsx
@@ -1,0 +1,98 @@
+import type { Control, FieldErrorsImpl } from 'react-hook-form'
+import type { Media } from '@/payload-types'
+
+import { Checkbox } from '@/components/ui/checkbox'
+import { Label } from '@/components/ui/label'
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
+import { ImageMedia } from '@/components/site/media/image-media'
+import React from 'react'
+import { Controller } from 'react-hook-form'
+
+import { Error } from '../error'
+import { Width } from '../width'
+
+interface ImageSelectOption {
+  label: string
+  value: string
+  image?: Media | number
+}
+
+interface ImageSelectField {
+  blockName?: string
+  blockType: 'image-select'
+  name: string
+  label?: string
+  options: ImageSelectOption[]
+  required?: boolean
+  width?: number
+  allowMultiple?: boolean
+}
+
+export const ImageSelect: React.FC<
+  ImageSelectField & {
+    control: Control
+    errors: Partial<FieldErrorsImpl>
+  }
+> = ({ name, control, errors, label, options, required, width, allowMultiple }) => {
+  return (
+    <Width width={width}>
+      <Label className="mb-2" htmlFor={name}>
+        {label}
+        {required && (
+          <span className="required">
+            * <span className="sr-only">(required)</span>
+          </span>
+        )}
+      </Label>
+      <Controller
+        control={control}
+        defaultValue={allowMultiple ? [] : ''}
+        name={name}
+        render={({ field: { onChange, value } }) => (
+          allowMultiple ? (
+            <div id={name} className="flex flex-wrap gap-4">
+              {options.map(({ label, value: optionValue, image }) => {
+                const checked = Array.isArray(value) && value.includes(optionValue)
+                return (
+                  <label key={optionValue} className="flex flex-col items-center space-y-2">
+                    {image && typeof image === 'object' && (
+                      <ImageMedia resource={image} imgClassName="h-24 w-24 object-cover rounded-md" />
+                    )}
+                    <Checkbox
+                      id={`${name}-${optionValue}`}
+                      checked={checked}
+                      onCheckedChange={(isChecked) => {
+                        if (Array.isArray(value)) {
+                          if (isChecked) onChange([...value, optionValue])
+                          else onChange(value.filter((v) => v !== optionValue))
+                        } else {
+                          onChange(isChecked ? [optionValue] : [])
+                        }
+                      }}
+                    />
+                    <span>{label}</span>
+                  </label>
+                )
+              })}
+            </div>
+          ) : (
+            <RadioGroup id={name} value={value} onValueChange={onChange} className="flex flex-wrap gap-4">
+              {options.map(({ label, value: optionValue, image }) => (
+                <label key={optionValue} className="flex flex-col items-center space-y-2">
+                  {image && typeof image === 'object' && (
+                    <ImageMedia resource={image} imgClassName="h-24 w-24 object-cover rounded-md" />
+                  )}
+                  <RadioGroupItem value={optionValue} />
+                  <span>{label}</span>
+                </label>
+              ))}
+            </RadioGroup>
+          )
+        )}
+        rules={{ required }}
+      />
+      {errors[name] && <Error />}
+    </Width>
+  )
+}
+

--- a/src/lib/plugins.ts
+++ b/src/lib/plugins.ts
@@ -97,6 +97,43 @@ export const plugins: Plugin[] = [
         ],
         labels: { singular: 'Checkbox Group', plural: 'Checkbox Groups' },
       } as any,
+      'image-select': {
+        slug: 'image-select',
+        fields: [
+          {
+            type: 'row',
+            fields: [
+              { name: 'name', type: 'text', label: 'Name (lowercase, no special characters)', required: true, admin: { width: '50%' } },
+              { name: 'label', type: 'text', label: 'Label', localized: true, admin: { width: '50%' } },
+            ],
+          },
+          {
+            type: 'row',
+            fields: [
+              { name: 'width', type: 'number', label: 'Field Width (percentage)', admin: { width: '50%' } },
+              { name: 'allowMultiple', type: 'checkbox', label: 'Allow Multiple Selections', admin: { width: '50%' } },
+            ],
+          },
+          {
+            name: 'options',
+            type: 'array',
+            label: 'Options',
+            labels: { singular: 'Option', plural: 'Options' },
+            fields: [
+              {
+                type: 'row',
+                fields: [
+                  { name: 'label', type: 'text', label: 'Label', localized: true, required: true, admin: { width: '33%' } },
+                  { name: 'value', type: 'text', label: 'Value', required: true, admin: { width: '33%' } },
+                  { name: 'image', type: 'relationship', relationTo: 'media', label: 'Image', required: true, admin: { width: '33%' } },
+                ],
+              },
+            ],
+          },
+          { name: 'required', type: 'checkbox', label: 'Required' },
+        ],
+        labels: { singular: 'Image Select', plural: 'Image Selects' },
+      } as any,
     },
     formOverrides: {
       admin: { group: 'Forms & Submissions' },

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -851,6 +851,24 @@ export interface Form {
             blockName?: string | null;
             blockType: 'checkbox-group';
           }
+        | {
+            name: string;
+            label?: string | null;
+            width?: number | null;
+            allowMultiple?: boolean | null;
+            options?:
+              | {
+                  label: string;
+                  value: string;
+                  image: string | Media;
+                  id?: string | null;
+                }[]
+              | null;
+            required?: boolean | null;
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'image-select';
+          }
       )[]
     | null;
   submitButtonLabel?: string | null;
@@ -1994,6 +2012,25 @@ export interface FormsSelect<T extends boolean = true> {
                 | {
                     label?: T;
                     value?: T;
+                    id?: T;
+                  };
+              required?: T;
+              id?: T;
+              blockName?: T;
+            };
+        'image-select'?:
+          | T
+          | {
+              name?: T;
+              label?: T;
+              width?: T;
+              allowMultiple?: T;
+              options?:
+                | T
+                | {
+                    label?: T;
+                    value?: T;
+                    image?: T;
                     id?: T;
                   };
               required?: T;

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -143,6 +143,43 @@ export default buildConfig({
           ],
           labels: { singular: 'Checkbox Group', plural: 'Checkbox Groups' },
         } as any,
+        'image-select': {
+          slug: 'image-select',
+          fields: [
+            {
+              type: 'row',
+              fields: [
+                { name: 'name', type: 'text', label: 'Name (lowercase, no special characters)', required: true, admin: { width: '50%' } },
+                { name: 'label', type: 'text', label: 'Label', localized: true, admin: { width: '50%' } },
+              ],
+            },
+            {
+              type: 'row',
+              fields: [
+                { name: 'width', type: 'number', label: 'Field Width (percentage)', admin: { width: '50%' } },
+                { name: 'allowMultiple', type: 'checkbox', label: 'Allow Multiple Selections', admin: { width: '50%' } },
+              ],
+            },
+            {
+              name: 'options',
+              type: 'array',
+              label: 'Options',
+              labels: { singular: 'Option', plural: 'Options' },
+              fields: [
+                {
+                  type: 'row',
+                  fields: [
+                    { name: 'label', type: 'text', label: 'Label', localized: true, required: true, admin: { width: '33%' } },
+                    { name: 'value', type: 'text', label: 'Value', required: true, admin: { width: '33%' } },
+                    { name: 'image', type: 'relationship', relationTo: 'media', label: 'Image', required: true, admin: { width: '33%' } },
+                  ],
+                },
+              ],
+            },
+            { name: 'required', type: 'checkbox', label: 'Required' },
+          ],
+          labels: { singular: 'Image Select', plural: 'Image Selects' },
+        } as any,
       },
       formOverrides: {
         admin: { group: 'Forms & Submissions' },


### PR DESCRIPTION
## Summary
- add ImageSelect field for form builder with image options and multi-select support
- register ImageSelect in form block field map and form builder plugin config
- regenerate payload types

## Testing
- `pnpm generate:types`
- `pnpm lint`
- `pnpm build` (fails: cannot connect to MongoDB)


------
https://chatgpt.com/codex/tasks/task_e_689228539160832f9d88da8d8e25cd64