### PR TITLE
feat: add image select form field

### DIFF
--- a/src/components/blocks/form-block/fields.tsx
+++ b/src/components/blocks/form-block/fields.tsx
@@ -5,6 +5,7 @@ import { Message } from './message'
 import { Number } from './number'
 import { Radio } from './radio'
 import { CheckboxGroup } from './checkbox-group'
+import { ImageSelect } from './image-select'
 import { Select } from './select'
 import { State } from './state'
 import { Text } from './text'
@@ -18,6 +19,7 @@ export const fields = {
   number: Number,
   radio: Radio,
   'checkbox-group': CheckboxGroup,
+  'image-select': ImageSelect,
   select: Select,
   state: State,
   text: Text,

--- a/src/components/blocks/form-block/image-select/index.tsx
+++ b/src/components/blocks/form-block/image-select/index.tsx
@@ -1,0 +1,118 @@
+import type { Control, FieldErrorsImpl } from 'react-hook-form'
+
+import { Checkbox } from '@/components/ui/checkbox'
+import { Label } from '@/components/ui/label'
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
+import Image from 'next/image'
+import React from 'react'
+import { Controller } from 'react-hook-form'
+
+import { Error } from '../error'
+import { Width } from '../width'
+
+interface MediaType {
+  url?: string
+  alt?: string
+}
+
+interface ImageSelectOption {
+  label: string
+  value: string
+  image?: MediaType | string
+}
+
+interface ImageSelectField {
+  blockName?: string
+  blockType: 'image-select'
+  label?: string
+  name: string
+  options: ImageSelectOption[]
+  required?: boolean
+  allowMultiple?: boolean
+  width?: number
+}
+
+export const ImageSelect: React.FC<
+  ImageSelectField & {
+    control: Control
+    errors: Partial<FieldErrorsImpl>
+  }
+> = ({ name, control, errors, label, options, required, allowMultiple, width }) => {
+  return (
+    <Width width={width}>
+      <Label className="mb-2" htmlFor={name}>
+        {label}
+        {required && (
+          <span className="required">
+            * <span className="sr-only">(required)</span>
+          </span>
+        )}
+      </Label>
+      <Controller
+        control={control}
+        defaultValue={allowMultiple ? [] : ''}
+        name={name}
+        render={({ field: { onChange, value } }) => (
+          allowMultiple ? (
+            <div id={name} className="flex flex-col space-y-2">
+              {options.map(({ label: optionLabel, value: optionValue, image }) => {
+                const checked = Array.isArray(value) && value.includes(optionValue)
+                const imgURL = typeof image === 'object' && image && 'url' in image ? image.url : undefined
+                return (
+                  <label key={optionValue} className="flex items-center space-x-2">
+                    {imgURL && (
+                      <Image
+                        src={imgURL}
+                        alt={optionLabel || ''}
+                        width={64}
+                        height={64}
+                        className="h-16 w-16 object-cover"
+                      />
+                    )}
+                    <Checkbox
+                      id={`${name}-${optionValue}`}
+                      checked={checked}
+                      onCheckedChange={(isChecked) => {
+                        if (Array.isArray(value)) {
+                          if (isChecked) onChange([...value, optionValue])
+                          else onChange(value.filter((v) => v !== optionValue))
+                        } else {
+                          onChange(isChecked ? [optionValue] : [])
+                        }
+                      }}
+                    />
+                    <span>{optionLabel}</span>
+                  </label>
+                )
+              })}
+            </div>
+          ) : (
+            <RadioGroup onValueChange={onChange} value={value} id={name} className="flex flex-col space-y-2">
+              {options.map(({ label: optionLabel, value: optionValue, image }) => {
+                const imgURL = typeof image === 'object' && image && 'url' in image ? image.url : undefined
+                return (
+                  <label key={optionValue} className="flex items-center space-x-2">
+                    {imgURL && (
+                      <Image
+                        src={imgURL}
+                        alt={optionLabel || ''}
+                        width={64}
+                        height={64}
+                        className="h-16 w-16 object-cover"
+                      />
+                    )}
+                    <RadioGroupItem value={optionValue} />
+                    <span>{optionLabel}</span>
+                  </label>
+                )
+              })}
+            </RadioGroup>
+          )
+        )}
+        rules={{ required }}
+      />
+      {errors[name] && <Error />}
+    </Width>
+  )
+}
+

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -143,6 +143,76 @@ export default buildConfig({
           ],
           labels: { singular: 'Checkbox Group', plural: 'Checkbox Groups' },
         } as any,
+        'image-select': {
+          slug: 'image-select',
+          fields: [
+            {
+              type: 'row',
+              fields: [
+                {
+                  name: 'name',
+                  type: 'text',
+                  label: 'Name (lowercase, no special characters)',
+                  required: true,
+                  admin: { width: '50%' },
+                },
+                {
+                  name: 'label',
+                  type: 'text',
+                  label: 'Label',
+                  localized: true,
+                  admin: { width: '50%' },
+                },
+              ],
+            },
+            {
+              type: 'row',
+              fields: [
+                {
+                  name: 'width',
+                  type: 'number',
+                  label: 'Field Width (percentage)',
+                  admin: { width: '50%' },
+                },
+                {
+                  name: 'allowMultiple',
+                  type: 'checkbox',
+                  label: 'Allow Multiple Selections',
+                  admin: { width: '50%' },
+                },
+              ],
+            },
+            {
+              name: 'options',
+              type: 'array',
+              label: 'Options',
+              labels: { singular: 'Option', plural: 'Options' },
+              fields: [
+                {
+                  type: 'row',
+                  fields: [
+                    { name: 'label', type: 'text', label: 'Label', localized: true, required: true, admin: { width: '33%' } },
+                    { name: 'value', type: 'text', label: 'Value', required: true, admin: { width: '33%' } },
+                    {
+                      name: 'image',
+                      type: 'upload',
+                      relationTo: 'media',
+                      label: 'Image',
+                      admin: {
+                        width: '33%',
+                        components: {
+                          Field: '@payloadcms/ui/fields/Upload',
+                        },
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+            { name: 'required', type: 'checkbox', label: 'Required' },
+          ],
+          labels: { singular: 'Image Select', plural: 'Image Selects' },
+        } as any,
       },
       formOverrides: {
         admin: { group: 'Forms & Submissions' },


### PR DESCRIPTION
## Summary
- add ImageSelect field to render single or multi-select options with images
- register Image Select field in form builder configuration
- wire ImageSelect into form block field mapping
- display standard upload picker for ImageSelect option images

## Testing
- `pnpm lint`
- `pnpm generate:types`


------
https://chatgpt.com/codex/tasks/task_e_689228539160832f9d88da8d8e25cd64