### PR TITLE
Refactor tenant terminology and adjust collections

### DIFF
--- a/src/collections/Media.ts
+++ b/src/collections/Media.ts
@@ -29,10 +29,12 @@ export const Media: CollectionConfig = {
     {
       name: 'alt',
       type: 'text',
+      required: true,
     },
     {
       name: 'caption',
       type: 'richText',
+      required: true,
       editor: lexicalEditor({
         features: ({ rootFeatures }) => {
           return [...rootFeatures, FixedToolbarFeature(), InlineToolbarFeature()]

--- a/src/collections/Posts/index.ts
+++ b/src/collections/Posts/index.ts
@@ -15,14 +15,12 @@ import { BannerConfig } from '@/components/blocks/banner-block/config'
 import { CodeBlockConfig } from '@/components/blocks/code-block/config'
 import { MediaBlockConfig } from '@/components/blocks/media-block/config'
 import { generatePreviewPath } from '@/lib/utilities/generatePreviewPath'
-import { populateAuthors } from './hooks/populateAuthors'
 import { revalidateDelete, revalidatePost } from './hooks/revalidatePost'
 
 import {
   MetaDescriptionField,
   MetaImageField,
   MetaTitleField,
-  OverviewField,
   PreviewField,
 } from '@payloadcms/plugin-seo/fields'
 import { slugField } from '@/collections/fields/slug'
@@ -110,51 +108,32 @@ export const Posts: CollectionConfig<'posts'> = {
           label: 'Meta & SEO',
           fields: [
             {
-              name: 'relatedPosts',
-              type: 'relationship',
-              admin: {
-                position: 'sidebar',
-              },
-              filterOptions: ({ id }) => {
-                return {
-                  id: {
-                    not_in: [id],
-                  },
-                }
-              },
-              hasMany: true,
-              relationTo: 'posts',
+              name: 'meta',
+              label: 'SEO',
+              type: 'group',
+              fields: [
+                MetaTitleField({ hasGenerateFn: true, overrides: { required: true } }),
+                MetaImageField({ relationTo: 'media', overrides: { required: true } }),
+                MetaDescriptionField({ overrides: { required: true } }),
+                PreviewField({
+                  hasGenerateFn: true,
+                  titlePath: 'meta.title',
+                  descriptionPath: 'meta.description',
+                }),
+              ],
             },
             {
               name: 'categories',
               type: 'relationship',
-              admin: {
-                position: 'sidebar',
-              },
-              hasMany: true,
               relationTo: 'categories',
-            },
-            {
-              name: 'tags',
-              type: 'relationship',
-              relationTo: 'tags',
               hasMany: true,
-              admin: {
-                position: 'sidebar',
-              },
-            },
-            {
-              name: 'articleType',
-              type: 'relationship',
-              relationTo: 'article-types',
-              admin: {
-                position: 'sidebar',
-              },
+              required: true,
             },
             {
               name: 'keyTakeaways',
               label: 'Key Takeaways / TL;DR',
               type: 'array',
+              required: true,
               fields: [
                 {
                   name: 'point',
@@ -164,28 +143,27 @@ export const Posts: CollectionConfig<'posts'> = {
               ],
             },
             {
-              name: 'meta',
-              label: 'SEO',
-              type: 'group',
-              fields: [
-                OverviewField({
-                  titlePath: 'meta.title',
-                  descriptionPath: 'meta.description',
-                  imagePath: 'meta.image',
-                }),
-                MetaTitleField({
-                  hasGenerateFn: true,
-                }),
-                MetaImageField({
-                  relationTo: 'media',
-                }),
-                MetaDescriptionField({}),
-                PreviewField({
-                  hasGenerateFn: true,
-                  titlePath: 'meta.title',
-                  descriptionPath: 'meta.description',
-                }),
-              ],
+              name: 'articleType',
+              type: 'relationship',
+              relationTo: 'article-types',
+              required: true,
+            },
+            {
+              name: 'tags',
+              type: 'relationship',
+              relationTo: 'tags',
+              hasMany: true,
+            },
+            {
+              name: 'relatedPosts',
+              type: 'relationship',
+              relationTo: 'posts',
+              hasMany: true,
+              filterOptions: ({ id }) => ({
+                id: {
+                  not_in: [id],
+                },
+              }),
             },
           ],
         },
@@ -211,58 +189,11 @@ export const Posts: CollectionConfig<'posts'> = {
         ],
       },
     },
-    {
-      name: 'authors',
-      type: 'relationship',
-      admin: {
-        position: 'sidebar',
-      },
-      hasMany: true,
-      relationTo: 'users',
-    },
-    // This field is only used to populate the user data via the `populateAuthors` hook
-    // This is because the `user` collection has access control locked to protect user privacy
-    // GraphQL will also not return mutated user data that differs from the underlying schema
-    {
-      name: 'populatedAuthors',
-      type: 'array',
-      access: {
-        update: () => false,
-      },
-      admin: {
-        disabled: true,
-        readOnly: true,
-      },
-      fields: [
-        {
-          name: 'id',
-          type: 'text',
-        },
-        {
-          name: 'name',
-          type: 'text',
-        },
-      ],
-    },
-    {
-      name: 'overrideTenant',
-      label: 'Tenant Override',
-      type: 'relationship',
-      relationTo: 'tenants',
-      admin: {
-        position: 'sidebar',
-        condition: () => true, // always visible, can restrict to admin if needed
-      },
-      access: {
-        read: ({ req }) => !!(req.user && req.user.roles?.includes('super')),
-        update: ({ req }) => !!(req.user && req.user.roles?.includes('super')),
-      },
-    },
+    // Author fields removed
     ...slugField(),
   ],
   hooks: {
     afterChange: [revalidatePost],
-    afterRead: [populateAuthors],
     afterDelete: [revalidateDelete],
   },
   versions: {

--- a/src/collections/RepInfo/index.ts
+++ b/src/collections/RepInfo/index.ts
@@ -73,7 +73,7 @@ export const RepInfo: CollectionConfig = {
     },
     {
       name: 'x',
-      label: 'X',
+      label: 'X.com',
       type: 'text',
       required: false,
     },

--- a/src/collections/SiteSEO/index.ts
+++ b/src/collections/SiteSEO/index.ts
@@ -10,20 +10,20 @@ export const SiteSEO: CollectionConfig = {
     group: 'Site Settings',
     useAsTitle: 'title',
     defaultColumns: ['title', 'updatedAt'],
-    description: 'SEO metadata for the tenant home page',
+    description: 'SEO metadata for the site home page',
   },
   access: {
     read: () => true,
   },
   hooks: {
     beforeChange: [({ req, operation, originalDoc, data }) => {
-      // enforce singleton per tenant: block creating additional docs
+      // enforce singleton per site: block creating additional docs
       if (operation === 'create') {
         // @ts-ignore
         const tenant = data?.tenant || req.tenant?.id || req.user?.tenants?.[0]
         return req.payload.find({ collection: 'site-seo', where: { tenant: { equals: tenant } } }).then((existing) => {
           if (existing.docs.length > 0) {
-            throw new Error('Site SEO document already exists for this tenant')
+            throw new Error('Site SEO document already exists for this site')
           }
           return data
         })
@@ -58,18 +58,10 @@ export const SiteSEO: CollectionConfig = {
     },
     {
       name: 'tags',
-      type: 'array',
       label: 'Tags',
-      admin: {
-        description: 'Comma-separated keywords',
-      },
-      fields: [
-        {
-          name: 'tag',
-          type: 'text',
-          required: true,
-        },
-      ],
+      type: 'relationship',
+      relationTo: 'tags',
+      hasMany: true,
     },
   ],
 }

--- a/src/collections/Tenants.ts
+++ b/src/collections/Tenants.ts
@@ -3,8 +3,8 @@ import type { CollectionConfig } from 'payload'
 export const Tenants: CollectionConfig = {
   slug: 'tenants',
   labels: {
-    singular: 'Tenant',
-    plural: 'Tenants',
+    singular: 'Site',
+    plural: 'Sites',
   },
   admin: {
     useAsTitle: 'name',
@@ -34,7 +34,7 @@ export const Tenants: CollectionConfig = {
       defaultValue: false,
       admin: { position: 'sidebar' },
     },
-    // add more tenant-level metadata here (e.g., domain, theme)
+    // add more site-level metadata here (e.g., domain, theme)
   ],
 }
 

--- a/src/collections/WordpressPosts/index.ts
+++ b/src/collections/WordpressPosts/index.ts
@@ -1,9 +1,9 @@
 import type { CollectionConfig } from 'payload'
 import { generatePreviewPath } from '@/lib/utilities/generatePreviewPath'
 
-// Collection for legacy WordPress posts. These documents are tenant-enabled by the
+// Collection for legacy WordPress posts. These documents are site-enabled by the
 // multi-tenant plugin, so a hidden `tenant` field will be injected automatically.
-// All imported posts will initially belong to the Candelora tenant via the import script.
+// All imported posts will initially belong to the Candelora site via the import script.
 export const WordpressPosts: CollectionConfig<'wordpress-posts'> = {
   labels: {
     singular: 'Wordpress Archive',

--- a/src/components/admin/CustomDashboard.tsx
+++ b/src/components/admin/CustomDashboard.tsx
@@ -16,7 +16,7 @@ const GROUPS: Record<string, { slug: string; label: string }[]> = {
   Admin: [
     { slug: 'categories', label: 'Categories' },
     { slug: 'users', label: 'Users' },
-    { slug: 'tenants', label: 'Tenants' },
+    { slug: 'tenants', label: 'Sites' },
   ],
   Misc: [
     { slug: 'authors', label: 'Authors' },

--- a/src/lib/plugins.ts
+++ b/src/lib/plugins.ts
@@ -5,15 +5,14 @@ import { nestedDocsPlugin } from '@payloadcms/plugin-nested-docs'
 import { redirectsPlugin } from '@payloadcms/plugin-redirects'
 import { seoPlugin } from '@payloadcms/plugin-seo'
 import { searchPlugin } from '@payloadcms/plugin-search'
-import { Plugin } from 'payload'
+import { Plugin, type Field } from 'payload'
 import { revalidateRedirects } from '@/lib/hooks/revalidateRedirects'
 import { GenerateTitle, GenerateURL } from '@payloadcms/plugin-seo/types'
-import { FixedToolbarFeature, HeadingFeature, lexicalEditor } from '@payloadcms/richtext-lexical'
 import { searchFields } from '@/lib/search/fieldOverrides'
 import { beforeSyncWithSearch } from '@/lib/search/beforeSync'
 import { config } from '@/site.config'
 
-import { Page, Post, User } from '@/payload-types'
+import { Page, Post } from '@/payload-types'
 import { getServerSideURL } from '@/lib/utilities/getURL'
 
 const generateTitle: GenerateTitle<Post | Page> = ({ doc }) => {
@@ -199,7 +198,8 @@ export const plugins: Plugin[] = [
   payloadCloudPlugin(),
   // Multi-tenant must run first so other plugins respect tenant scoping
   multiTenantPlugin({
-    tenantsSlug: 'tenants',     // identify the Tenants collection
+    tenantsSlug: 'tenants', // identify the Tenants collection
+    tenantSelectorLabel: 'Select Site',
     // disable tenant-based access constraints for admins
     useTenantsCollectionAccess: true,
     useTenantsListFilter: true,
@@ -221,4 +221,22 @@ export const plugins: Plugin[] = [
       'form-submissions': {},
     },
   }),
+  // Rename tenant field labels to use "Site" terminology
+  (config) => {
+    config.collections?.forEach((collection) => {
+      const traverse = (fields: Field[]): void => {
+        fields.forEach((field) => {
+          if ('name' in field && field.name === 'tenant') field.label = 'Site'
+          if ('name' in field && field.name === 'tenants') field.label = 'Sites'
+          if ('fields' in field && Array.isArray(field.fields)) {
+            traverse(field.fields as Field[])
+          }
+        })
+      }
+      if (Array.isArray(collection.fields)) {
+        traverse(collection.fields as Field[])
+      }
+    })
+    return config
+  },
 ]

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -128,6 +128,7 @@ export default buildConfig({
     s3Storage({
       collections: { media: true },
       bucket: process.env.R2_BUCKET || '',
+      clientUploads: true,
       config: {
         endpoint: process.env.R2_ENDPOINT || '',
         credentials: {

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -10,7 +10,7 @@ type Config = {
 }
 
 export const config: Config = {
-  name: 'Payload Site Starter ✴︎',
+  name: 'Connecticut House Republicans',
   url: 'https://payload-site-starter.vercel.app',
   description: 'Opinionated starter for building websites with Payload and Next.js',
   logo: {


### PR DESCRIPTION
## Summary
- rename Tenants to Sites across admin UI and tenant selector
- streamline Posts meta fields and remove author/tenant override
- require Media alt & caption; enable client uploads
- update Site SEO tags relation and Rep Info X.com label

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6896b90f1774832f814a0152cf85c921