### PR TITLE
Disable paste URL uploads and serve media from R2

### DIFF
--- a/src/collections/Media.ts
+++ b/src/collections/Media.ts
@@ -79,5 +79,6 @@ export const Media: CollectionConfig = {
         crop: 'center',
       },
     ],
+    pasteURL: false,
   },
 }

--- a/src/components/site/media/image-media/index.tsx
+++ b/src/components/site/media/image-media/index.tsx
@@ -8,7 +8,6 @@ import React from 'react'
 
 import type { Props as MediaProps } from '../types'
 
-import { getClientSideURL } from '@/lib/utilities/getURL'
 
 const breakpoints = {
   '3xl': 1920,
@@ -49,7 +48,9 @@ export const ImageMedia: React.FC<MediaProps> = (props) => {
 
     const cacheTag = resource.updatedAt
 
-    src = `${getClientSideURL()}${url}?${cacheTag}`
+    if (url) {
+      src = `${url}?${cacheTag}`
+    }
   }
 
   const loading = loadingFromProps || (!priority ? 'lazy' : undefined)

--- a/src/components/site/media/video-media/index.tsx
+++ b/src/components/site/media/video-media/index.tsx
@@ -5,7 +5,6 @@ import React, { useEffect, useRef } from 'react'
 
 import type { Props as MediaProps } from '../types'
 
-import { getClientSideURL } from '@/lib/utilities/getURL'
 
 export const VideoMedia: React.FC<MediaProps> = (props) => {
   const { onClick, resource, videoClassName } = props
@@ -24,7 +23,8 @@ export const VideoMedia: React.FC<MediaProps> = (props) => {
   }, [])
 
   if (resource && typeof resource === 'object') {
-    // const { filename } = resource
+    const src = resource.url
+    if (!src) return null
 
     return (
       <video
@@ -37,7 +37,7 @@ export const VideoMedia: React.FC<MediaProps> = (props) => {
         playsInline
         ref={videoRef}
       >
-        <source src={`${getClientSideURL()}${resource.url}`} />
+        <source src={src} />
       </video>
     )
   }

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -126,7 +126,12 @@ export default buildConfig({
 
     // S3 storage plugin for media uploads
     s3Storage({
-      collections: { media: true },
+      collections: {
+        media: {
+          disablePayloadAccessControl: true,
+          generateFileURL: ({ filename }) => `https://media.cthousegop.com/${filename}`,
+        },
+      },
       bucket: process.env.R2_BUCKET || '',
       clientUploads: true,
       config: {


### PR DESCRIPTION
## Summary
- turn off Paste-URL flow for Media uploads and require alt/caption
- serve media directly from media.cthousegop.com via R2 storage plugin
- use media URLs returned by Payload in image and video components

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Error: cannot connect to MongoDB)*

------
https://chatgpt.com/codex/tasks/task_e_689756b6080c832fbb83bc69e7176e13