### PR TITLE
feat: add tenant breadcrumb

### DIFF
--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -44,6 +44,7 @@ import { TenantSelector as TenantSelector_1d0591e3cf4f332c83a86da13a0de59a } fro
 import { TenantSelectionProvider as TenantSelectionProvider_d6d5f193a167989e2ee7d14202901e62 } from '@payloadcms/plugin-multi-tenant/rsc'
 import { S3ClientUploadHandler as S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24 } from '@payloadcms/storage-s3/client'
 import { default as default_d9529890fa20de5c8f810a9f7021b88f } from '../../../components/admin/CustomDashboard'
+import { TenantBreadcrumb as TenantBreadcrumb_4c9c0703c7f0f3a5b99a9f875f4c6bd5 } from '../../../components/admin/TenantBreadcrumb'
 
 export const importMap = {
   "@payloadcms/plugin-multi-tenant/client#TenantField": TenantField_1d0591e3cf4f332c83a86da13a0de59a,
@@ -91,5 +92,6 @@ export const importMap = {
   "@payloadcms/plugin-multi-tenant/client#TenantSelector": TenantSelector_1d0591e3cf4f332c83a86da13a0de59a,
   "@payloadcms/plugin-multi-tenant/rsc#TenantSelectionProvider": TenantSelectionProvider_d6d5f193a167989e2ee7d14202901e62,
   "@payloadcms/storage-s3/client#S3ClientUploadHandler": S3ClientUploadHandler_f97aa6c64367fa259c5bc0567239ef24,
-  "./components/admin/CustomDashboard#default": default_d9529890fa20de5c8f810a9f7021b88f
+  "./components/admin/CustomDashboard#default": default_d9529890fa20de5c8f810a9f7021b88f,
+  "./components/admin/TenantBreadcrumb#TenantBreadcrumb": TenantBreadcrumb_4c9c0703c7f0f3a5b99a9f875f4c6bd5
 }

--- a/src/components/admin/TenantBreadcrumb.tsx
+++ b/src/components/admin/TenantBreadcrumb.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import React from 'react'
+import Link from 'next/link'
+import { useTenantSelection } from '@payloadcms/plugin-multi-tenant/client'
+
+export const TenantBreadcrumb = ({ children }: { children?: React.ReactNode }) => {
+  const { selectedTenantID, options } = useTenantSelection()
+  const label = options.find((o) => o.value === selectedTenantID)?.label
+
+  if (!label) {
+    return <>{children}</>
+  }
+
+  return (
+    <>
+      <li>
+        <Link href="/admin">{label}</Link>
+      </li>
+      {children}
+    </>
+  )
+}
+
+export default TenantBreadcrumb

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -37,6 +37,9 @@ const dirname = path.dirname(filename);
 export default buildConfig({
   admin: {
     components: {
+      Breadcrumbs: {
+        Component: './components/admin/TenantBreadcrumb',
+      },
       views: {
         Dashboard: {
           Component: './components/admin/CustomDashboard',


### PR DESCRIPTION
## Summary
- inject tenant breadcrumb linking to dashboard
- wire up breadcrumb component in payload config

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68b6729c0d20832f96671be2fb6c5f3e